### PR TITLE
Fix new member join message

### DIFF
--- a/discord/init.js
+++ b/discord/init.js
@@ -32,7 +32,7 @@ exports.connect = function () {
 
         //When a member joins the server
         client.on("guildMemberAdd", function (newMember) {
-            newMember.send(welcomeMessage(newMember));
+            newMember.send(welcomeMessage(newMember.user));
         });
 
         //When a member messages bot


### PR DESCRIPTION
newMember is of type GuildMember but welcomeMessage expects type User so that .username can be used