### PR TITLE
Add user message modification

### DIFF
--- a/discord/interpreter.js
+++ b/discord/interpreter.js
@@ -213,7 +213,8 @@ module.exports.handleCom = async (message, client) => {
                 } else {
                     Logger.log("info", "Admin channel found. Sending message...");
                     channel.send(`New user ${message.author.username} (real name apparently ${realName}, fresher: ${fresherStr}, identification provided: ${identification}) has requested to join the server.
-If the user seems legitimate, please add them via \`!insertuser ${message.author.username}, ${fresher ? "fresher" : "non-fresher"}, ${realName}\``);
+If the user seems legitimate, please add them via:`);
+                    channel.send(`!insertuser ${message.author.username}, ${fresher ? "fresher" : "non-fresher"}, ${realName}`);
                     await message.channel.send(
                         `Thanks for registering! A ${conf().Discord.AdminRole} member should review your request shortly.
 If your roles do not change within the next few hours, feel free to PM a ${conf().Discord.AdminRole}`);

--- a/discord/interpreter.js
+++ b/discord/interpreter.js
@@ -214,7 +214,7 @@ module.exports.handleCom = async (message, client) => {
                     Logger.log("info", "Admin channel found. Sending message...");
                     channel.send(`New user ${message.author.username} (real name apparently ${realName}, fresher: ${fresherStr}, identification provided: ${identification}) has requested to join the server.
 If the user seems legitimate, please add them via:`);
-                    channel.send(`!insertuser ${message.author.username}, ${fresher ? "fresher" : "non-fresher"}, ${realName}`);
+                    channel.send(`\`!insertuser ${message.author.username}, ${fresher ? "fresher" : "non-fresher"}, ${realName}\``);
                     await message.channel.send(
                         `Thanks for registering! A ${conf().Discord.AdminRole} member should review your request shortly.
 If your roles do not change within the next few hours, feel free to PM a ${conf().Discord.AdminRole}`);


### PR DESCRIPTION
Splits add user message into 2 so that the second message can easily be copied and pasted from mobile devices. This was requested by a committee member